### PR TITLE
[JTC] Accepting different number of number of `joints` and `command_joints` parameter

### DIFF
--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -27,9 +27,25 @@ jobs:
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
           import-token: ${{ secrets.GITHUB_TOKEN }}
-          # build all packages listed in the meta package
+          # build all packages listed here
           package-name:
+            ackermann_steering_controller
+            admittance_controller
+            bicycle_steering_controller
             diff_drive_controller
+            effort_controllers
+            force_torque_sensor_broadcaster
+            forward_command_controller
+            gripper_controllers
+            imu_sensor_broadcaster
+            joint_state_broadcaster
+            joint_trajectory_controller
+            position_controllers
+            range_sensor_broadcaster
+            steering_controllers_library
+            tricycle_controller
+            tricycle_steering_controller
+            velocity_controllers
 
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_controllers-not-released.${{ env.ROS_DISTRO }}.repos?token=${{ secrets.GITHUB_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,8 @@ coverage:
     patch: off
 fixes:
   - "ros_ws/src/ros2_controllers/::"
+ignore:
+  - "**/test"
 comment:
   layout: "diff, flags, files"
   behavior: default

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -71,15 +71,13 @@ public:
   JointTrajectoryController();
 
   /**
-   * @brief command_interface_configuration This controller requires the position command
-   * interfaces for the controlled joints
+   * @brief command_interface_configuration
    */
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   controller_interface::InterfaceConfiguration command_interface_configuration() const override;
 
   /**
-   * @brief command_interface_configuration This controller requires the position and velocity
-   * state interfaces for the controlled joints
+   * @brief command_interface_configuration
    */
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   controller_interface::InterfaceConfiguration state_interface_configuration() const override;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -280,9 +280,9 @@ private:
 
   void init_hold_position_msg();
   void resize_joint_trajectory_point(
-    trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size, double vale = 0.0);
+    trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size, double value = 0.0);
   void resize_joint_trajectory_point_command(
-    trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size, double vale = 0.0);
+    trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size, double value = 0.0);
 };
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -280,9 +280,9 @@ private:
 
   void init_hold_position_msg();
   void resize_joint_trajectory_point(
-    trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size);
+    trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size, double vale = 0.0);
   void resize_joint_trajectory_point_command(
-    trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size);
+    trajectory_msgs::msg::JointTrajectoryPoint & point, size_t size, double vale = 0.0);
 };
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -133,6 +133,8 @@ protected:
 
   // Degrees of freedom
   size_t dof_;
+  size_t num_cmd_joints_;
+  std::vector<size_t> map_cmd_to_joints_;
 
   // Storing command joint names for interfaces
   std::vector<std::string> command_joint_names_;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -15,6 +15,7 @@
 #ifndef JOINT_TRAJECTORY_CONTROLLER__TRAJECTORY_HPP_
 #define JOINT_TRAJECTORY_CONTROLLER__TRAJECTORY_HPP_
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -187,6 +188,17 @@ inline std::vector<size_t> mapping(const T & t1, const T & t2)
     }
   }
   return mapping_vector;
+}
+
+/**
+ * \return True if \p B is a subset of \p A, false otherwise.
+ */
+template <typename T>
+bool is_subset(std::vector<T> A, std::vector<T> B)
+{
+  std::sort(A.begin(), A.end());
+  std::sort(B.begin(), B.end());
+  return std::includes(A.begin(), A.end(), B.begin(), B.end());
 }
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -15,7 +15,6 @@
 #ifndef JOINT_TRAJECTORY_CONTROLLER__TRAJECTORY_HPP_
 #define JOINT_TRAJECTORY_CONTROLLER__TRAJECTORY_HPP_
 
-#include <algorithm>
 #include <memory>
 #include <vector>
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory.hpp
@@ -161,7 +161,7 @@ private:
 /**
  * \return The map between \p t1 indices (implicitly encoded in return vector indices) to \p t2
  * indices. If \p t1 is <tt>"{C, B}"</tt> and \p t2 is <tt>"{A, B, C, D}"</tt>, the associated
- * mapping vector is <tt>"{2, 1}"</tt>.
+ * mapping vector is <tt>"{2, 1}"</tt>. return empty vector if \p t1 is not a subset of \p t2.
  */
 template <class T>
 inline std::vector<size_t> mapping(const T & t1, const T & t2)
@@ -188,17 +188,6 @@ inline std::vector<size_t> mapping(const T & t1, const T & t2)
     }
   }
   return mapping_vector;
-}
-
-/**
- * \return True if \p B is a subset of \p A, false otherwise.
- */
-template <typename T>
-bool is_subset(std::vector<T> A, std::vector<T> B)
-{
-  std::sort(A.begin(), A.end());
-  std::sort(B.begin(), B.end());
-  return std::includes(A.begin(), A.end(), B.begin(), B.end());
 }
 
 }  // namespace joint_trajectory_controller

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -651,17 +651,7 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
   // get parameters from the listener in case they were updated
   params_ = param_listener_->get_params();
 
-  // Check if the DoF has changed
-  if ((dof_ > 0) && (params_.joints.size() != dof_))
-  {
-    RCLCPP_ERROR(
-      logger,
-      "The JointTrajectoryController does not support restarting with a different number of DOF");
-    // TODO(andyz): update vector lengths if num. joints did change and re-initialize them so we
-    // can continue
-    return CallbackReturn::FAILURE;
-  }
-
+  // get degrees of freedom
   dof_ = params_.joints.size();
 
   // TODO(destogl): why is this here? Add comment or move
@@ -690,12 +680,6 @@ controller_interface::CallbackReturn JointTrajectoryController::on_configure(
       logger, "'command_joints' parameter has to have the same size as 'joints' parameter.");
     return CallbackReturn::FAILURE;
   }
-
-  //  // Specialized, child controllers set interfaces before calling configure function.
-  //  if (command_interface_types_.empty())
-  //  {
-  //   command_interface_types_ = get_node()->get_parameter("command_interfaces").as_string_array();
-  //  }
 
   if (params_.command_interfaces.empty())
   {

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -1028,6 +1028,10 @@ controller_interface::CallbackReturn JointTrajectoryController::on_activate(
   // those are not nan
   trajectory_msgs::msg::JointTrajectoryPoint state;
   resize_joint_trajectory_point(state, dof_);
+  // read from cmd joints only if all joints have command interface
+  // otherwise it leaves the entries of joints without command interface NaN.
+  // if no open_loop control, state_current_ is then used for `set_point_before_trajectory_msg` and
+  // future trajectory sampling will always give NaN for these joints
   if (dof_ == num_cmd_joints_ && read_state_from_command_interfaces(state))
   {
     state_current_ = state;

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -280,11 +280,12 @@ controller_interface::return_type JointTrajectoryController::update(
           // Update PIDs
           for (auto i = 0ul; i < num_cmd_joints_; ++i)
           {
-            size_t index = map_cmd_to_joints_[i];
-            tmp_command_[index] = (state_desired_.velocities[index] * ff_velocity_scale_[i]) +
-                                  pids_[i]->computeCommand(
-                                    state_error_.positions[index], state_error_.velocities[index],
-                                    (uint64_t)period.nanoseconds());
+            size_t index_cmd_joint = map_cmd_to_joints_[i];
+            tmp_command_[index_cmd_joint] =
+              (state_desired_.velocities[index_cmd_joint] * ff_velocity_scale_[index_cmd_joint]) +
+              pids_[i]->computeCommand(
+                state_error_.positions[index_cmd_joint], state_error_.velocities[index_cmd_joint],
+                (uint64_t)period.nanoseconds());
           }
         }
 

--- a/joint_trajectory_controller/test/test_trajectory_actions.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_actions.cpp
@@ -30,9 +30,7 @@
 #include "action_msgs/msg/goal_status_array.hpp"
 #include "control_msgs/action/detail/follow_joint_trajectory__struct.hpp"
 #include "controller_interface/controller_interface.hpp"
-#include "gtest/gtest.h"
 #include "hardware_interface/resource_manager.hpp"
-#include "joint_trajectory_controller/joint_trajectory_controller.hpp"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/executors/multi_threaded_executor.hpp"
@@ -45,9 +43,11 @@
 #include "rclcpp_action/client_goal_handle.hpp"
 #include "rclcpp_action/create_client.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
-#include "test_trajectory_controller_utils.hpp"
 #include "trajectory_msgs/msg/joint_trajectory.hpp"
 #include "trajectory_msgs/msg/joint_trajectory_point.hpp"
+
+#include "joint_trajectory_controller/joint_trajectory_controller.hpp"
+#include "test_trajectory_controller_utils.hpp"
 
 using std::placeholders::_1;
 using std::placeholders::_2;

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -26,13 +26,10 @@
 #include <thread>
 #include <vector>
 
-#include "gmock/gmock.h"
-
 #include "builtin_interfaces/msg/duration.hpp"
 #include "builtin_interfaces/msg/time.hpp"
 #include "controller_interface/controller_interface.hpp"
 #include "hardware_interface/resource_manager.hpp"
-#include "joint_trajectory_controller/joint_trajectory_controller.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/duration.hpp"
@@ -52,6 +49,7 @@
 #include "trajectory_msgs/msg/joint_trajectory.hpp"
 #include "trajectory_msgs/msg/joint_trajectory_point.hpp"
 
+#include "joint_trajectory_controller/joint_trajectory_controller.hpp"
 #include "test_trajectory_controller_utils.hpp"
 
 using lifecycle_msgs::msg::State;

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -398,7 +398,6 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
 /**
  * @brief check if state topic is consistent with parameters
  */
-
 TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency)
 {
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -499,7 +498,6 @@ TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency)
 /**
  * @brief same as state_topic_consistency but with #command-joints < #dof
  */
-
 TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency_command_joints_less_than_dof)
 {
   rclcpp::executors::SingleThreadedExecutor executor;

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -60,6 +60,10 @@ using test_trajectory_controllers::TrajectoryControllerTestParameterized;
 
 void spin(rclcpp::executors::MultiThreadedExecutor * exe) { exe->spin(); }
 
+// Floating-point value comparison threshold
+const double EPS = 1e-6;
+
+#if 0
 TEST_P(TrajectoryControllerTestParameterized, configure_state_ignores_commands)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
@@ -175,7 +179,81 @@ TEST_P(TrajectoryControllerTestParameterized, check_interface_names_with_command
   ASSERT_THAT(
     command_interfaces.names, testing::UnorderedElementsAreArray(command_interface_names));
 }
+#endif
 
+TEST_P(
+  TrajectoryControllerTestParameterized, check_interface_names_with_command_joints_less_than_dof)
+{
+  rclcpp::executors::MultiThreadedExecutor executor;
+  // set command_joints parameter
+  std::vector<std::string> command_joint_names{joint_names_[0], joint_names_[1]};
+  const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names);
+  SetUpTrajectoryController(executor, {command_joint_names_param});
+
+  const auto state = traj_controller_->get_node()->configure();
+  ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
+
+  std::vector<std::string> state_interface_names;
+  state_interface_names.reserve(joint_names_.size() * state_interface_types_.size());
+  for (const auto & joint : joint_names_)
+  {
+    for (const auto & interface : state_interface_types_)
+    {
+      state_interface_names.push_back(joint + "/" + interface);
+    }
+  }
+  auto state_interfaces = traj_controller_->state_interface_configuration();
+  EXPECT_EQ(state_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
+  EXPECT_EQ(state_interfaces.names.size(), joint_names_.size() * state_interface_types_.size());
+  ASSERT_THAT(state_interfaces.names, testing::UnorderedElementsAreArray(state_interface_names));
+
+  std::vector<std::string> command_interface_names;
+  command_interface_names.reserve(command_joint_names.size() * command_interface_types_.size());
+  for (const auto & joint : command_joint_names)
+  {
+    for (const auto & interface : command_interface_types_)
+    {
+      command_interface_names.push_back(joint + "/" + interface);
+    }
+  }
+  auto command_interfaces = traj_controller_->command_interface_configuration();
+  EXPECT_EQ(
+    command_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
+  EXPECT_EQ(
+    command_interfaces.names.size(), command_joint_names.size() * command_interface_types_.size());
+  ASSERT_THAT(
+    command_interfaces.names, testing::UnorderedElementsAreArray(command_interface_names));
+}
+
+TEST_P(
+  TrajectoryControllerTestParameterized, check_interface_names_with_command_joints_greater_than_dof)
+{
+  rclcpp::executors::MultiThreadedExecutor executor;
+  // set command_joints parameter
+  std::vector<std::string> command_joint_names{
+    joint_names_[0], joint_names_[1], joint_names_[2], "joint_4"};
+  const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names);
+  SetUpTrajectoryController(executor, {command_joint_names_param});
+
+  const auto state = traj_controller_->get_node()->configure();
+  ASSERT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+}
+
+TEST_P(
+  TrajectoryControllerTestParameterized,
+  check_interface_names_with_command_joints_different_than_dof)
+{
+  rclcpp::executors::MultiThreadedExecutor executor;
+  // set command_joints parameter
+  std::vector<std::string> command_joint_names{joint_names_[0], "joint_4"};
+  const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names);
+  SetUpTrajectoryController(executor, {command_joint_names_param});
+
+  const auto state = traj_controller_->get_node()->configure();
+  ASSERT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
+}
+
+#if 0
 TEST_P(TrajectoryControllerTestParameterized, activate)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
@@ -413,7 +491,107 @@ TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency)
     EXPECT_EQ(n_joints, state->output.effort.size());
   }
 }
+#endif
 
+TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency_command_joints_less_than_dof)
+{
+  rclcpp::executors::SingleThreadedExecutor executor;
+  std::vector<std::string> command_joint_names{joint_names_[0], joint_names_[1]};
+  const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names);
+  SetUpAndActivateTrajectoryController(executor, {command_joint_names_param});
+  subscribeToState();
+  updateController();
+
+  // Spin to receive latest state
+  executor.spin_some();
+  auto state = getState();
+
+  size_t n_joints = joint_names_.size();
+
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    EXPECT_EQ(joint_names_[i], state->joint_names[i]);
+  }
+
+  // No trajectory by default, no reference state or error
+  EXPECT_TRUE(
+    state->reference.positions.empty() || state->reference.positions == INITIAL_POS_JOINTS);
+  EXPECT_TRUE(
+    state->reference.velocities.empty() || state->reference.velocities == INITIAL_VEL_JOINTS);
+  EXPECT_TRUE(
+    state->reference.accelerations.empty() || state->reference.accelerations == INITIAL_EFF_JOINTS);
+
+  std::vector<double> zeros(3, 0);
+  EXPECT_EQ(state->error.positions, zeros);
+  EXPECT_TRUE(state->error.velocities.empty() || state->error.velocities == zeros);
+  EXPECT_TRUE(state->error.accelerations.empty() || state->error.accelerations == zeros);
+
+  // expect feedback including all state_interfaces
+  EXPECT_EQ(n_joints, state->feedback.positions.size());
+  if (
+    std::find(state_interface_types_.begin(), state_interface_types_.end(), "velocity") ==
+    state_interface_types_.end())
+  {
+    EXPECT_TRUE(state->feedback.velocities.empty());
+  }
+  else
+  {
+    EXPECT_EQ(n_joints, state->feedback.velocities.size());
+  }
+  if (
+    std::find(state_interface_types_.begin(), state_interface_types_.end(), "acceleration") ==
+    state_interface_types_.end())
+  {
+    EXPECT_TRUE(state->feedback.accelerations.empty());
+  }
+  else
+  {
+    EXPECT_EQ(n_joints, state->feedback.accelerations.size());
+  }
+
+  // expect output including all command_interfaces
+  if (
+    std::find(command_interface_types_.begin(), command_interface_types_.end(), "position") ==
+    command_interface_types_.end())
+  {
+    EXPECT_TRUE(state->output.positions.empty());
+  }
+  else
+  {
+    EXPECT_EQ(n_joints, state->output.positions.size());
+  }
+  if (
+    std::find(command_interface_types_.begin(), command_interface_types_.end(), "velocity") ==
+    command_interface_types_.end())
+  {
+    EXPECT_TRUE(state->output.velocities.empty());
+  }
+  else
+  {
+    EXPECT_EQ(n_joints, state->output.velocities.size());
+  }
+  if (
+    std::find(command_interface_types_.begin(), command_interface_types_.end(), "acceleration") ==
+    command_interface_types_.end())
+  {
+    EXPECT_TRUE(state->output.accelerations.empty());
+  }
+  else
+  {
+    EXPECT_EQ(n_joints, state->output.accelerations.size());
+  }
+  if (
+    std::find(command_interface_types_.begin(), command_interface_types_.end(), "effort") ==
+    command_interface_types_.end())
+  {
+    EXPECT_TRUE(state->output.effort.empty());
+  }
+  else
+  {
+    EXPECT_EQ(n_joints, state->output.effort.size());
+  }
+}
+#if 0
 /**
  * @brief check if hold on startup is deactivated
  */
@@ -453,8 +631,6 @@ TEST_P(TrajectoryControllerTestParameterized, hold_on_startup)
   executor.cancel();
 }
 
-// Floating-point value comparison threshold
-const double EPS = 1e-6;
 /**
  * @brief check if position error of revolute joints are normalized if not configured so
  */
@@ -563,7 +739,119 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_not_normalized)
 
   executor.cancel();
 }
+#endif
 
+/**
+ * @brief check if position error of revolute joints are normalized if not configured so
+ */
+TEST_P(TrajectoryControllerTestParameterized, position_error_command_joints_less_than_dof)
+{
+  rclcpp::executors::MultiThreadedExecutor executor;
+  constexpr double k_p = 10.0;
+  std::vector<std::string> command_joint_names{joint_names_[0], joint_names_[1]};
+  const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names);
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("allow_nonzero_velocity_at_trajectory_end", true), command_joint_names_param};
+  SetUpAndActivateTrajectoryController(executor, params, true, k_p, 0.0, false);
+  subscribeToState();
+
+  size_t n_joints = joint_names_.size();
+
+  // send msg for all joints
+  constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(250);
+  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(FIRST_POINT_TIME)};
+  // *INDENT-OFF*
+  std::vector<std::vector<double>> points{
+    {{3.3, 4.4, 6.6}}, {{7.7, 8.8, 9.9}}, {{10.10, 11.11, 12.12}}};
+  std::vector<std::vector<double>> points_velocities{
+    {{0.01, 0.01, 0.01}}, {{0.05, 0.05, 0.05}}, {{0.06, 0.06, 0.06}}};
+  // *INDENT-ON*
+  publish(time_from_start, points, rclcpp::Time(), {}, points_velocities);
+  traj_controller_->wait_for_trajectory(executor);
+
+  // first update
+  updateController(rclcpp::Duration(FIRST_POINT_TIME));
+
+  // Spin to receive latest state
+  executor.spin_some();
+  auto state_msg = getState();
+  ASSERT_TRUE(state_msg);
+
+  const auto allowed_delta = 0.1;
+
+  // no update of state_interface
+  EXPECT_EQ(state_msg->feedback.positions, INITIAL_POS_JOINTS);
+
+  // has the msg the correct vector sizes?
+  EXPECT_EQ(n_joints, state_msg->reference.positions.size());
+  EXPECT_EQ(n_joints, state_msg->feedback.positions.size());
+  EXPECT_EQ(n_joints, state_msg->error.positions.size());
+
+  // are the correct reference positions used?
+  EXPECT_NEAR(points[0][0], state_msg->reference.positions[0], allowed_delta);
+  EXPECT_NEAR(points[0][1], state_msg->reference.positions[1], allowed_delta);
+  EXPECT_NEAR(points[0][2], state_msg->reference.positions[2], 3 * allowed_delta);
+
+  // no normalization of position error
+  EXPECT_NEAR(
+    state_msg->error.positions[0], state_msg->reference.positions[0] - INITIAL_POS_JOINTS[0], EPS);
+  EXPECT_NEAR(
+    state_msg->error.positions[1], state_msg->reference.positions[1] - INITIAL_POS_JOINTS[1], EPS);
+  EXPECT_NEAR(
+    state_msg->error.positions[2], state_msg->reference.positions[2] - INITIAL_POS_JOINTS[2], EPS);
+
+  if (traj_controller_->has_position_command_interface())
+  {
+    // check command interface
+    EXPECT_NEAR(points[0][0], joint_pos_[0], allowed_delta);
+    EXPECT_NEAR(points[0][1], joint_pos_[1], allowed_delta);
+    EXPECT_NEAR(points[0][2], joint_pos_[2], allowed_delta);
+    EXPECT_NEAR(points[0][0], state_msg->output.positions[0], allowed_delta);
+    EXPECT_NEAR(points[0][1], state_msg->output.positions[1], allowed_delta);
+    EXPECT_NEAR(points[0][2], state_msg->output.positions[2], allowed_delta);
+  }
+
+  if (traj_controller_->has_velocity_command_interface())
+  {
+    // check command interface
+    EXPECT_LT(0.0, joint_vel_[0]);
+    EXPECT_LT(0.0, joint_vel_[1]);
+    EXPECT_LT(0.0, joint_vel_[2]);
+    EXPECT_LT(0.0, state_msg->output.velocities[0]);
+    EXPECT_LT(0.0, state_msg->output.velocities[1]);
+    EXPECT_LT(0.0, state_msg->output.velocities[2]);
+
+    // use_closed_loop_pid_adapter_
+    if (traj_controller_->use_closed_loop_pid_adapter())
+    {
+      // we expect u = k_p * (s_d-s)
+      EXPECT_NEAR(
+        k_p * (state_msg->reference.positions[0] - INITIAL_POS_JOINTS[0]), joint_vel_[0],
+        k_p * allowed_delta);
+      EXPECT_NEAR(
+        k_p * (state_msg->reference.positions[1] - INITIAL_POS_JOINTS[1]), joint_vel_[1],
+        k_p * allowed_delta);
+      // no normalization of position error
+      EXPECT_NEAR(
+        k_p * (state_msg->reference.positions[2] - INITIAL_POS_JOINTS[2]), joint_vel_[2],
+        k_p * allowed_delta);
+    }
+  }
+
+  if (traj_controller_->has_effort_command_interface())
+  {
+    // check command interface
+    EXPECT_LT(0.0, joint_eff_[0]);
+    EXPECT_LT(0.0, joint_eff_[1]);
+    EXPECT_LT(0.0, joint_eff_[2]);
+    EXPECT_LT(0.0, state_msg->output.effort[0]);
+    EXPECT_LT(0.0, state_msg->output.effort[1]);
+    EXPECT_LT(0.0, state_msg->output.effort[2]);
+  }
+
+  executor.cancel();
+}
+#if 0
 /**
  * @brief cmd_timeout must be greater than constraints.goal_time
  */
@@ -1832,7 +2120,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_goal_tolerances_fail)
   // it should be still holding the old point
   expectHoldingPoint(hold_position);
 }
-
+#endif
 // position controllers
 INSTANTIATE_TEST_SUITE_P(
   PositionTrajectoryControllers, TrajectoryControllerTestParameterized,

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -63,7 +63,6 @@ void spin(rclcpp::executors::MultiThreadedExecutor * exe) { exe->spin(); }
 // Floating-point value comparison threshold
 const double EPS = 1e-6;
 
-#if 0
 TEST_P(TrajectoryControllerTestParameterized, configure_state_ignores_commands)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
@@ -179,7 +178,6 @@ TEST_P(TrajectoryControllerTestParameterized, check_interface_names_with_command
   ASSERT_THAT(
     command_interfaces.names, testing::UnorderedElementsAreArray(command_interface_names));
 }
-#endif
 
 TEST_P(
   TrajectoryControllerTestParameterized, check_interface_names_with_command_joints_less_than_dof)
@@ -253,7 +251,6 @@ TEST_P(
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_UNCONFIGURED);
 }
 
-#if 0
 TEST_P(TrajectoryControllerTestParameterized, activate)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
@@ -491,7 +488,6 @@ TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency)
     EXPECT_EQ(n_joints, state->output.effort.size());
   }
 }
-#endif
 
 TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency_command_joints_less_than_dof)
 {
@@ -591,7 +587,7 @@ TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency_command_jo
     EXPECT_EQ(n_joints, state->output.effort.size());
   }
 }
-#if 0
+
 /**
  * @brief check if hold on startup is deactivated
  */
@@ -739,12 +735,11 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_not_normalized)
 
   executor.cancel();
 }
-#endif
 
 /**
- * @brief check if position error of revolute joints are normalized if not configured so
+ * @brief check if trajectory error is calculated correctly in case #command-joints < #dof
  */
-TEST_P(TrajectoryControllerTestParameterized, position_error_command_joints_less_than_dof)
+TEST_P(TrajectoryControllerTestParameterized, trajectory_error_command_joints_less_than_dof)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
   constexpr double k_p = 10.0;
@@ -805,10 +800,9 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_command_joints_less
     // check command interface
     EXPECT_NEAR(points[0][0], joint_pos_[0], allowed_delta);
     EXPECT_NEAR(points[0][1], joint_pos_[1], allowed_delta);
-    EXPECT_NEAR(points[0][2], joint_pos_[2], allowed_delta);
     EXPECT_NEAR(points[0][0], state_msg->output.positions[0], allowed_delta);
     EXPECT_NEAR(points[0][1], state_msg->output.positions[1], allowed_delta);
-    EXPECT_NEAR(points[0][2], state_msg->output.positions[2], allowed_delta);
+    EXPECT_TRUE(std::isnan(state_msg->output.positions[2]));
   }
 
   if (traj_controller_->has_velocity_command_interface())
@@ -816,10 +810,9 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_command_joints_less
     // check command interface
     EXPECT_LT(0.0, joint_vel_[0]);
     EXPECT_LT(0.0, joint_vel_[1]);
-    EXPECT_LT(0.0, joint_vel_[2]);
     EXPECT_LT(0.0, state_msg->output.velocities[0]);
     EXPECT_LT(0.0, state_msg->output.velocities[1]);
-    EXPECT_LT(0.0, state_msg->output.velocities[2]);
+    EXPECT_TRUE(std::isnan(state_msg->output.velocities[2]));
 
     // use_closed_loop_pid_adapter_
     if (traj_controller_->use_closed_loop_pid_adapter())
@@ -831,9 +824,109 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_command_joints_less
       EXPECT_NEAR(
         k_p * (state_msg->reference.positions[1] - INITIAL_POS_JOINTS[1]), joint_vel_[1],
         k_p * allowed_delta);
-      // no normalization of position error
+    }
+  }
+
+  if (traj_controller_->has_effort_command_interface())
+  {
+    // check command interface
+    EXPECT_LT(0.0, joint_eff_[0]);
+    EXPECT_LT(0.0, joint_eff_[1]);
+    EXPECT_LT(0.0, state_msg->output.effort[0]);
+    EXPECT_LT(0.0, state_msg->output.effort[1]);
+    EXPECT_TRUE(std::isnan(state_msg->output.effort[2]));
+  }
+
+  executor.cancel();
+}
+
+/**
+ * @brief check if trajectory error is calculated correctly in case #command-joints < #dof
+ */
+TEST_P(TrajectoryControllerTestParameterized, trajectory_error_command_joints_less_than_dof_jumbled)
+{
+  rclcpp::executors::MultiThreadedExecutor executor;
+  constexpr double k_p = 10.0;
+  std::vector<std::string> command_joint_names{joint_names_[1], joint_names_[0]};
+  const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names);
+  std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("allow_nonzero_velocity_at_trajectory_end", true), command_joint_names_param};
+  SetUpAndActivateTrajectoryController(executor, params, true, k_p, 0.0, false);
+  subscribeToState();
+
+  size_t n_joints = joint_names_.size();
+
+  // send msg for all joints
+  constexpr auto FIRST_POINT_TIME = std::chrono::milliseconds(250);
+  builtin_interfaces::msg::Duration time_from_start{rclcpp::Duration(FIRST_POINT_TIME)};
+  // *INDENT-OFF*
+  std::vector<std::vector<double>> points{
+    {{3.3, 4.4, 6.6}}, {{7.7, 8.8, 9.9}}, {{10.10, 11.11, 12.12}}};
+  std::vector<std::vector<double>> points_velocities{
+    {{0.01, 0.01, 0.01}}, {{0.05, 0.05, 0.05}}, {{0.06, 0.06, 0.06}}};
+  // *INDENT-ON*
+  publish(time_from_start, points, rclcpp::Time(), {}, points_velocities);
+  traj_controller_->wait_for_trajectory(executor);
+
+  // first update
+  updateController(rclcpp::Duration(FIRST_POINT_TIME));
+
+  // Spin to receive latest state
+  executor.spin_some();
+  auto state_msg = getState();
+  ASSERT_TRUE(state_msg);
+
+  const auto allowed_delta = 0.1;
+
+  // no update of state_interface
+  EXPECT_EQ(state_msg->feedback.positions, INITIAL_POS_JOINTS);
+
+  // has the msg the correct vector sizes?
+  EXPECT_EQ(n_joints, state_msg->reference.positions.size());
+  EXPECT_EQ(n_joints, state_msg->feedback.positions.size());
+  EXPECT_EQ(n_joints, state_msg->error.positions.size());
+
+  // are the correct reference positions used?
+  EXPECT_NEAR(points[0][0], state_msg->reference.positions[0], allowed_delta);
+  EXPECT_NEAR(points[0][1], state_msg->reference.positions[1], allowed_delta);
+  EXPECT_NEAR(points[0][2], state_msg->reference.positions[2], 3 * allowed_delta);
+
+  // no normalization of position error
+  EXPECT_NEAR(
+    state_msg->error.positions[0], state_msg->reference.positions[0] - INITIAL_POS_JOINTS[0], EPS);
+  EXPECT_NEAR(
+    state_msg->error.positions[1], state_msg->reference.positions[1] - INITIAL_POS_JOINTS[1], EPS);
+  EXPECT_NEAR(
+    state_msg->error.positions[2], state_msg->reference.positions[2] - INITIAL_POS_JOINTS[2], EPS);
+
+  if (traj_controller_->has_position_command_interface())
+  {
+    // check command interface
+    EXPECT_NEAR(points[0][0], joint_pos_[0], allowed_delta);
+    EXPECT_NEAR(points[0][1], joint_pos_[1], allowed_delta);
+    EXPECT_NEAR(points[0][0], state_msg->output.positions[0], allowed_delta);
+    EXPECT_NEAR(points[0][1], state_msg->output.positions[1], allowed_delta);
+    EXPECT_TRUE(std::isnan(state_msg->output.positions[2]));
+  }
+
+  if (traj_controller_->has_velocity_command_interface())
+  {
+    // check command interface
+    EXPECT_LT(0.0, joint_vel_[0]);
+    EXPECT_LT(0.0, joint_vel_[1]);
+    EXPECT_LT(0.0, state_msg->output.velocities[0]);
+    EXPECT_LT(0.0, state_msg->output.velocities[1]);
+    EXPECT_TRUE(std::isnan(state_msg->output.velocities[2]));
+
+    // use_closed_loop_pid_adapter_
+    if (traj_controller_->use_closed_loop_pid_adapter())
+    {
+      // we expect u = k_p * (s_d-s)
       EXPECT_NEAR(
-        k_p * (state_msg->reference.positions[2] - INITIAL_POS_JOINTS[2]), joint_vel_[2],
+        k_p * (state_msg->reference.positions[0] - INITIAL_POS_JOINTS[0]), joint_vel_[0],
+        k_p * allowed_delta);
+      EXPECT_NEAR(
+        k_p * (state_msg->reference.positions[1] - INITIAL_POS_JOINTS[1]), joint_vel_[1],
         k_p * allowed_delta);
     }
   }
@@ -843,15 +936,14 @@ TEST_P(TrajectoryControllerTestParameterized, position_error_command_joints_less
     // check command interface
     EXPECT_LT(0.0, joint_eff_[0]);
     EXPECT_LT(0.0, joint_eff_[1]);
-    EXPECT_LT(0.0, joint_eff_[2]);
     EXPECT_LT(0.0, state_msg->output.effort[0]);
     EXPECT_LT(0.0, state_msg->output.effort[1]);
-    EXPECT_LT(0.0, state_msg->output.effort[2]);
+    EXPECT_TRUE(std::isnan(state_msg->output.effort[2]));
   }
 
   executor.cancel();
 }
-#if 0
+
 /**
  * @brief cmd_timeout must be greater than constraints.goal_time
  */
@@ -2120,7 +2212,7 @@ TEST_P(TrajectoryControllerTestParameterized, test_goal_tolerances_fail)
   // it should be still holding the old point
   expectHoldingPoint(hold_position);
 }
-#endif
+
 // position controllers
 INSTANTIATE_TEST_SUITE_P(
   PositionTrajectoryControllers, TrajectoryControllerTestParameterized,

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -179,6 +179,9 @@ TEST_P(TrajectoryControllerTestParameterized, check_interface_names_with_command
     command_interfaces.names, testing::UnorderedElementsAreArray(command_interface_names));
 }
 
+/**
+ * \brief same as check_interface_names_with_command_joints but with #command-joints < #dof
+ */
 TEST_P(
   TrajectoryControllerTestParameterized, check_interface_names_with_command_joints_less_than_dof)
 {
@@ -392,6 +395,10 @@ TEST_P(TrajectoryControllerTestParameterized, correct_initialization_using_param
   executor.cancel();
 }
 
+/**
+ * @brief check if state topic is consistent with parameters
+ */
+
 TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency)
 {
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -488,6 +495,10 @@ TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency)
     EXPECT_EQ(n_joints, state->output.effort.size());
   }
 }
+
+/**
+ * @brief same as state_topic_consistency but with #command-joints < #dof
+ */
 
 TEST_P(TrajectoryControllerTestParameterized, state_topic_consistency_command_joints_less_than_dof)
 {
@@ -841,7 +852,8 @@ TEST_P(TrajectoryControllerTestParameterized, trajectory_error_command_joints_le
 }
 
 /**
- * @brief check if trajectory error is calculated correctly in case #command-joints < #dof
+ * @brief check if trajectory error is calculated correctly in case #command-joints < #dof, but with
+ * jumbled order of command joints
  */
 TEST_P(TrajectoryControllerTestParameterized, trajectory_error_command_joints_less_than_dof_jumbled)
 {

--- a/joint_trajectory_controller/test/test_trajectory_controller.cpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller.cpp
@@ -106,77 +106,20 @@ TEST_P(TrajectoryControllerTestParameterized, check_interface_names)
   const auto state = traj_controller_->get_node()->configure();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 
-  std::vector<std::string> state_interface_names;
-  state_interface_names.reserve(joint_names_.size() * state_interface_types_.size());
-  for (const auto & joint : joint_names_)
-  {
-    for (const auto & interface : state_interface_types_)
-    {
-      state_interface_names.push_back(joint + "/" + interface);
-    }
-  }
-  auto state_interfaces = traj_controller_->state_interface_configuration();
-  EXPECT_EQ(state_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
-  EXPECT_EQ(state_interfaces.names.size(), joint_names_.size() * state_interface_types_.size());
-  ASSERT_THAT(state_interfaces.names, testing::UnorderedElementsAreArray(state_interface_names));
-
-  std::vector<std::string> command_interface_names;
-  command_interface_names.reserve(joint_names_.size() * command_interface_types_.size());
-  for (const auto & joint : joint_names_)
-  {
-    for (const auto & interface : command_interface_types_)
-    {
-      command_interface_names.push_back(joint + "/" + interface);
-    }
-  }
-  auto command_interfaces = traj_controller_->command_interface_configuration();
-  EXPECT_EQ(
-    command_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
-  EXPECT_EQ(command_interfaces.names.size(), joint_names_.size() * command_interface_types_.size());
-  ASSERT_THAT(
-    command_interfaces.names, testing::UnorderedElementsAreArray(command_interface_names));
+  compare_joints(joint_names_, joint_names_);
 }
 
 TEST_P(TrajectoryControllerTestParameterized, check_interface_names_with_command_joints)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
-  // set command_joints parameter
+  // set command_joints parameter different than joint_names_
   const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names_);
   SetUpTrajectoryController(executor, {command_joint_names_param});
 
   const auto state = traj_controller_->get_node()->configure();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 
-  std::vector<std::string> state_interface_names;
-  state_interface_names.reserve(joint_names_.size() * state_interface_types_.size());
-  for (const auto & joint : joint_names_)
-  {
-    for (const auto & interface : state_interface_types_)
-    {
-      state_interface_names.push_back(joint + "/" + interface);
-    }
-  }
-  auto state_interfaces = traj_controller_->state_interface_configuration();
-  EXPECT_EQ(state_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
-  EXPECT_EQ(state_interfaces.names.size(), joint_names_.size() * state_interface_types_.size());
-  ASSERT_THAT(state_interfaces.names, testing::UnorderedElementsAreArray(state_interface_names));
-
-  std::vector<std::string> command_interface_names;
-  command_interface_names.reserve(command_joint_names_.size() * command_interface_types_.size());
-  for (const auto & joint : command_joint_names_)
-  {
-    for (const auto & interface : command_interface_types_)
-    {
-      command_interface_names.push_back(joint + "/" + interface);
-    }
-  }
-  auto command_interfaces = traj_controller_->command_interface_configuration();
-  EXPECT_EQ(
-    command_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
-  EXPECT_EQ(
-    command_interfaces.names.size(), command_joint_names_.size() * command_interface_types_.size());
-  ASSERT_THAT(
-    command_interfaces.names, testing::UnorderedElementsAreArray(command_interface_names));
+  compare_joints(joint_names_, command_joint_names_);
 }
 
 /**
@@ -186,7 +129,7 @@ TEST_P(
   TrajectoryControllerTestParameterized, check_interface_names_with_command_joints_less_than_dof)
 {
   rclcpp::executors::MultiThreadedExecutor executor;
-  // set command_joints parameter
+  // set command_joints parameter to a subset of joint_names_
   std::vector<std::string> command_joint_names{joint_names_[0], joint_names_[1]};
   const rclcpp::Parameter command_joint_names_param("command_joints", command_joint_names);
   SetUpTrajectoryController(executor, {command_joint_names_param});
@@ -194,36 +137,7 @@ TEST_P(
   const auto state = traj_controller_->get_node()->configure();
   ASSERT_EQ(state.id(), State::PRIMARY_STATE_INACTIVE);
 
-  std::vector<std::string> state_interface_names;
-  state_interface_names.reserve(joint_names_.size() * state_interface_types_.size());
-  for (const auto & joint : joint_names_)
-  {
-    for (const auto & interface : state_interface_types_)
-    {
-      state_interface_names.push_back(joint + "/" + interface);
-    }
-  }
-  auto state_interfaces = traj_controller_->state_interface_configuration();
-  EXPECT_EQ(state_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
-  EXPECT_EQ(state_interfaces.names.size(), joint_names_.size() * state_interface_types_.size());
-  ASSERT_THAT(state_interfaces.names, testing::UnorderedElementsAreArray(state_interface_names));
-
-  std::vector<std::string> command_interface_names;
-  command_interface_names.reserve(command_joint_names.size() * command_interface_types_.size());
-  for (const auto & joint : command_joint_names)
-  {
-    for (const auto & interface : command_interface_types_)
-    {
-      command_interface_names.push_back(joint + "/" + interface);
-    }
-  }
-  auto command_interfaces = traj_controller_->command_interface_configuration();
-  EXPECT_EQ(
-    command_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
-  EXPECT_EQ(
-    command_interfaces.names.size(), command_joint_names.size() * command_interface_types_.size());
-  ASSERT_THAT(
-    command_interfaces.names, testing::UnorderedElementsAreArray(command_interface_names));
+  compare_joints(joint_names_, command_joint_names);
 }
 
 TEST_P(

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -221,14 +221,10 @@ public:
     bool separate_cmd_and_state_values = false, double k_p = 0.0, double ff = 1.0,
     bool normalize_error = false)
   {
-    SetUpTrajectoryController(executor);
+    SetUpTrajectoryController(executor, parameters);
 
     // set pid parameters before configure
     SetPidParameters(k_p, ff, normalize_error);
-    for (const auto & param : parameters)
-    {
-      traj_controller_->get_node()->set_parameter(param);
-    }
     // ignore velocity tolerances for this test since they aren't committed in test_robot->write()
     rclcpp::Parameter stopped_velocity_parameters("constraints.stopped_velocity_tolerance", 0.0);
     traj_controller_->get_node()->set_parameter(stopped_velocity_parameters);

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "joint_trajectory_controller/joint_trajectory_controller.hpp"

--- a/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
+++ b/joint_trajectory_controller/test/test_trajectory_controller_utils.hpp
@@ -540,6 +540,47 @@ public:
     }
   }
 
+  /**
+   * @brief compares the joint names and interface types of the controller with the given ones
+   */
+  void compare_joints(
+    std::vector<std::string> state_joint_names, std::vector<std::string> command_joint_names)
+  {
+    std::vector<std::string> state_interface_names;
+    state_interface_names.reserve(state_joint_names.size() * state_interface_types_.size());
+    for (const auto & joint : state_joint_names)
+    {
+      for (const auto & interface : state_interface_types_)
+      {
+        state_interface_names.push_back(joint + "/" + interface);
+      }
+    }
+    auto state_interfaces = traj_controller_->state_interface_configuration();
+    EXPECT_EQ(
+      state_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
+    EXPECT_EQ(
+      state_interfaces.names.size(), state_joint_names.size() * state_interface_types_.size());
+    ASSERT_THAT(state_interfaces.names, testing::UnorderedElementsAreArray(state_interface_names));
+
+    std::vector<std::string> command_interface_names;
+    command_interface_names.reserve(command_joint_names.size() * command_interface_types_.size());
+    for (const auto & joint : command_joint_names)
+    {
+      for (const auto & interface : command_interface_types_)
+      {
+        command_interface_names.push_back(joint + "/" + interface);
+      }
+    }
+    auto command_interfaces = traj_controller_->command_interface_configuration();
+    EXPECT_EQ(
+      command_interfaces.type, controller_interface::interface_configuration_type::INDIVIDUAL);
+    EXPECT_EQ(
+      command_interfaces.names.size(),
+      command_joint_names.size() * command_interface_types_.size());
+    ASSERT_THAT(
+      command_interfaces.names, testing::UnorderedElementsAreArray(command_interface_names));
+  }
+
   std::string controller_name_;
 
   std::vector<std::string> joint_names_;


### PR DESCRIPTION
This PR weakens the condition that the number of `joints` and `command_joints` have to be equal: It now supports having less `command_joints` than `joints`.

This gives the opportunity to track the state and error of passive joints, i.e., joints that are not `command_joints`. As an example, think of a pendulum on a cart. Now it is possible to send a swing-up trajectory of the pendulum including values of the cart and the pendulum, but JTC commands only the cart.

Next step would be the possibility to implement different controllers than PID, e.g., a state-space controller.

More details
- `command_joints` must be a subset of `joints` if they don't have the same size.
- If they have the same size, a 1:1 mapping is assumed independent of the values of `command_joints`. (see `check_interface_names_with_command_joints` test)
- `~/controller_state` topic uses a single `joint_names` vector for all fields. Entries of the output field being not included in `command_joints` will be NaN.
